### PR TITLE
Add support for CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ GLOBAL OPTIONS:
    --url "http://localhost:3000"    a URL to the deployster instance [$DEPLOYSTER_URL]
    --username "deployster"          username for authenticating to deployster [$DEPLOYSTER_USERNAME]
    --password                       password for authenticating to deployster [$DEPLOYSTER_PASSWORD]
+   --ca-cert                        path of CA certificate to use for connecting via SSL [$DEPLOYSTER_CA_CERT]
    --help, -h                       show help
    --version, -v                    print the version
 ```

--- a/commands/client.go
+++ b/commands/client.go
@@ -9,5 +9,7 @@ func getClientFromContext(ctx *cli.Context) *client.Client {
 	username := ctx.GlobalString("username")
 	password := ctx.GlobalString("password")
 	baseURL := ctx.GlobalString("url")
-	return client.New(baseURL, username, password)
+	caCert := ctx.GlobalString("ca-cert")
+
+	return client.New(baseURL, username, password, caCert)
 }

--- a/deployctl.go
+++ b/deployctl.go
@@ -18,6 +18,7 @@ func main() {
 		cli.StringFlag{Name: "url", Value: "http://localhost:3000", Usage: "a URL to the deployster instance", EnvVar: "DEPLOYSTER_URL"},
 		cli.StringFlag{Name: "username", Value: "deployster", Usage: "username for authenticating to deployster", EnvVar: "DEPLOYSTER_USERNAME"},
 		cli.StringFlag{Name: "password", Value: "", Usage: "password for authenticating to deployster", EnvVar: "DEPLOYSTER_PASSWORD"},
+		cli.StringFlag{Name: "ca-cert", Value: "", Usage: "path of CA certificate to use for connecting via SSL", EnvVar: "DEPLOYSTER_CA_CERT"},
 	}
 	app.Commands = []cli.Command{
 		commands.NewDeployCommand(),


### PR DESCRIPTION
Add support for `--ca-cert` flag for passing the path of a CA certificate to use for connecting via SSL.
